### PR TITLE
Issue99: allow to cleanup threadlocals. check existence of closure in cu...

### DIFF
--- a/src/main/java/ch/lambdaj/Lambda.java
+++ b/src/main/java/ch/lambdaj/Lambda.java
@@ -1346,4 +1346,17 @@ public final class Lambda {
     public static <T> ClosureResult<T> delayedClosure(DelayedClosure<T> delayedClosure) {
         return delayedClosure.getClosureResult();
     }
+
+    /**
+     * Cleans objects bound to current thread local. This is safety net to prevent
+     * ClassLoader's memory leaks when application is running at thread-pool environment.
+     * Typicaly when running on application servers like Tomcat which uses WebappClassLoader
+     * to load .war applications.
+     */
+    public static void cleanupLambdaJ() {
+        ArgumentsFactory.cleanupLimitedValueArguments();
+        ClosuresFactory.cleanupClosures();
+        DelayedClosure.cleanupDelayed();
+    }
+
 }

--- a/src/main/java/ch/lambdaj/function/argument/ArgumentsFactory.java
+++ b/src/main/java/ch/lambdaj/function/argument/ArgumentsFactory.java
@@ -283,4 +283,12 @@ public final class ArgumentsFactory {
     private static boolean isShort(Class<?> clazz) {
         return clazz == Short.TYPE || clazz == Short.class;
     }
+
+    /**
+     * Cleans limited value placeholders currently bound to actual thread's thread local.
+     */
+    public static void cleanupLimitedValueArguments() {
+        LIMITED_VALUE_ARGUMENTS.remove();
+    }
+
 }

--- a/src/main/java/ch/lambdaj/function/closure/DelayedClosure.java
+++ b/src/main/java/ch/lambdaj/function/closure/DelayedClosure.java
@@ -71,4 +71,12 @@ public abstract class DelayedClosure<T> {
     private void execute() {
         result = doWithClosure(closure);
     }
+
+    /**
+     * Cleans delayed closures currently bound to actual thread's thread local.
+     */
+    public static void cleanupDelayed() {
+        CURRENT_DELAYED.remove();
+    }
+
 }

--- a/src/main/java/ch/lambdaj/function/closure/UndefinedClosureException.java
+++ b/src/main/java/ch/lambdaj/function/closure/UndefinedClosureException.java
@@ -1,0 +1,19 @@
+package ch.lambdaj.function.closure;
+
+/**
+ * This Exception is thrown when trying to bindClosure and closure is not defined in current context
+ * @author Ivo Smid
+ */
+public class UndefinedClosureException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    UndefinedClosureException(String message) {
+        super(message);
+    }
+
+    UndefinedClosureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/test/java/ch/lambdaj/ClosureTest.java
+++ b/src/test/java/ch/lambdaj/ClosureTest.java
@@ -34,6 +34,11 @@ public class ClosureTest {
 		int nonCommutativeDoOnInt(int val1, int val2, int val3, int val4);
 	}
 
+    @Test(expected = UndefinedClosureException.class)
+    public void testUndefinedClosure() {
+        of(System.out).println(var(String.class));
+    }
+
 	@Test
 	public void testSystemOut() {
 		Closure1<String> println = closure(String.class); { of(System.out).println(var(String.class)); }


### PR DESCRIPTION
...rrent thread local when binding closures

Hi,
I have created fix to Issue 99 I have reported. There are new methods to clean up thread locals to prevent memory leak while running at thread-pooled environment with custom class loaders - for example: running on Tomcat's WebappClassLoader.
Problematic is reference to web app classloader while application reload. 
ThreadPool -> Thread -> ThreadLocal -> INSTANCE <- Class <- ClassLoader .
I was thinking about using Weak/SoftReference but they do not fit enough to this problem.
I hope this fix is good enough :]
Ivos
